### PR TITLE
Return nulls not empty strings

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,5 +72,14 @@ for (let i = 0; i < regexes.user_agent_parsers.length; i++) {
 
 vcl += `} else {
   set req.http.ua_family = "Other";
+}
+if (req.http.ua_major == "") {
+  unset req.http.ua_major;
+}
+if (req.http.ua_minor == "") {
+  unset req.http.ua_minor;
+}
+if (req.http.ua_patch == "") {
+  unset req.http.ua_patch;
 }\n`;
 console.log(vcl);

--- a/uap.vcl
+++ b/uap.vcl
@@ -1221,4 +1221,13 @@ if (req.http.user-agent ~ "(ESPN)[%2520| ]+Radio/(\d+)\.(\d+)\.(\d+) CFNetwork")
 } else {
   set req.http.ua_family = "Other";
 }
+if (req.http.ua_major == "") {
+  unset req.http.ua_major;
+}
+if (req.http.ua_minor == "") {
+  unset req.http.ua_minor;
+}
+if (req.http.ua_patch == "") {
+  unset req.http.ua_patch;
+}
 


### PR DESCRIPTION
Some of the regular expressions have an empty alternation at the end of
the match, such as:

`(Java)[/ ]{0,1}\d+\.(\d+)\.(\d+)[_-]*([a-zA-Z0-9]+|)`

This results in an empty string being returned, rather than null. This
commit makes sure to return nulls.